### PR TITLE
Fix tooltips obstructing model + allow placing anything in head slot

### DIFF
--- a/Common/src/main/java/fuzs/armorstatues/api/client/gui/screens/armorstand/ArmorStandRotationsScreen.java
+++ b/Common/src/main/java/fuzs/armorstatues/api/client/gui/screens/armorstand/ArmorStandRotationsScreen.java
@@ -103,12 +103,14 @@ public class ArmorStandRotationsScreen extends AbstractArmorStandScreen {
         ArmorStandPose.checkMutatorsSize(values);
         for (int i = 0; i < values.length; i++) {
             PosePartMutator mutator = values[i];
+            boolean isLeft = i % 2 == 0;
             this.addRenderableWidget(new BoxedSliderButton(this.leftPos + 23 + i % 2 * 110, this.topPos + 7 + i / 2 * 60, () -> mutator.getNormalizedRotationsAtAxis(1, this.currentPose, clampRotations), () -> mutator.getNormalizedRotationsAtAxis(0, this.currentPose, clampRotations), (button, poseStack, mouseX, mouseY) -> {
                 List<Component> lines = Lists.newArrayList();
                 lines.add(mutator.getComponent());
                 lines.add(mutator.getAxisComponent(this.currentPose, 0));
                 lines.add(mutator.getAxisComponent(this.currentPose, 1));
-                this.renderTooltip(poseStack, lines.stream().map(Component::getVisualOrderText).collect(Collectors.toList()), mouseX, mouseY);
+                int offset = isLeft ? 24 + lines.stream().mapToInt(minecraft.font::width).max().orElse(0) : 0;
+                this.renderTooltip(poseStack, lines.stream().map(Component::getVisualOrderText).collect(Collectors.toList()), mouseX - offset, mouseY);
             }) {
                 private boolean dirty;
 
@@ -137,7 +139,8 @@ public class ArmorStandRotationsScreen extends AbstractArmorStandScreen {
                 List<Component> lines = Lists.newArrayList();
                 lines.add(mutator.getComponent());
                 lines.add(mutator.getAxisComponent(this.currentPose, 2));
-                this.renderTooltip(poseStack, lines.stream().map(Component::getVisualOrderText).collect(Collectors.toList()), mouseX, mouseY);
+                int offset = isLeft ? 24 + lines.stream().mapToInt(minecraft.font::width).max().orElse(0) : 0;
+                this.renderTooltip(poseStack, lines.stream().map(Component::getVisualOrderText).collect(Collectors.toList()), mouseX - offset, mouseY);
             }) {
                 private boolean dirty;
 

--- a/Common/src/main/java/fuzs/armorstatues/api/world/inventory/ArmorStandMenu.java
+++ b/Common/src/main/java/fuzs/armorstatues/api/world/inventory/ArmorStandMenu.java
@@ -95,6 +95,9 @@ public class ArmorStandMenu extends AbstractContainerMenu implements ArmorStandH
                             return false;
                         }
                     }
+                    if (equipmentslot == EquipmentSlot.HEAD) {
+                        return true;
+                    }
                     return ModServices.ABSTRACTIONS.canEquip(stack, equipmentslot, inventory.player);
                 }
 


### PR DESCRIPTION
Vanilla minecraft renders any item in the head slot, some even have special positioning (like bone and feather), so why not allow placing any item there.

When moving sliders on the left side of rotations tab, tooltips were obstructing armor stand, so I fixed that:
![img](https://user-images.githubusercontent.com/40513410/196229868-b3aadc70-d788-46e5-8abf-1dabc2e1e588.png)
