### PR TITLE
No Hitbox (Marker) Flag

### DIFF
--- a/Common/src/main/java/fuzs/armorstatues/api/world/inventory/data/ArmorStandStyleOptions.java
+++ b/Common/src/main/java/fuzs/armorstatues/api/world/inventory/data/ArmorStandStyleOptions.java
@@ -19,7 +19,8 @@ public enum ArmorStandStyleOptions implements ArmorStandStyleOption {
     SEALED("sealed", (armorStand, setting) -> {
         armorStand.setInvulnerable(setting);
         ((ArmorStandAccessor) armorStand).setDisabledSlots(setting ? ArmorStandStyleOption.ARMOR_STAND_ALL_SLOTS_DISABLED : 0);
-    }, Entity::isInvulnerable);
+    }, Entity::isInvulnerable),
+    NO_HITBOX("noHitbox", (armorStand, setting) -> ArmorStandStyleOption.setArmorStandData(armorStand, setting, ArmorStand.CLIENT_FLAG_MARKER), armorStand -> ArmorStandStyleOption.getArmorStandData(armorStand, ArmorStand.CLIENT_FLAG_MARKER));
 
     private final String translationId;
     private final BiConsumer<ArmorStand, Boolean> newValue;
@@ -56,6 +57,7 @@ public enum ArmorStandStyleOptions implements ArmorStandStyleOption {
             case NO_BASE_PLATE -> "NoBasePlate";
             case NO_GRAVITY -> "NoGravity";
             case SEALED -> "Invulnerable";
+            case NO_HITBOX -> "Marker";
         };
         tag.putBoolean(dataKey, currentValue);
         if (this == ArmorStandStyleOptions.SEALED) {

--- a/Common/src/main/java/fuzs/armorstatues/mixin/accessor/ArmorStandAccessor.java
+++ b/Common/src/main/java/fuzs/armorstatues/mixin/accessor/ArmorStandAccessor.java
@@ -3,6 +3,7 @@ package fuzs.armorstatues.mixin.accessor;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.decoration.ArmorStand;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,6 +15,9 @@ public interface ArmorStandAccessor {
 
     @Accessor
     NonNullList<ItemStack> getHandItems();
+
+    @Invoker("getDimensionsMarker")
+    EntityDimensions getArmorstandDimensions(boolean marker);
 
     @Accessor
     NonNullList<ItemStack> getArmorItems();

--- a/Common/src/main/java/fuzs/armorstatues/mixin/redirect/MarkerArmorStandRaytracer.java
+++ b/Common/src/main/java/fuzs/armorstatues/mixin/redirect/MarkerArmorStandRaytracer.java
@@ -1,0 +1,36 @@
+package fuzs.armorstatues.mixin.redirect;
+
+import fuzs.armorstatues.mixin.accessor.ArmorStandAccessor;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.decoration.ArmorStand;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.ProjectileUtil;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.function.Predicate;
+
+@Mixin(ProjectileUtil.class)
+public class MarkerArmorStandRaytracer {
+    @Redirect(method = "getEntityHitResult(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/AABB;Ljava/util/function/Predicate;D)Lnet/minecraft/world/phys/EntityHitResult;",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/Entity;getBoundingBox()Lnet/minecraft/world/phys/AABB;"))
+    private static AABB getBoundingBox(Entity a, Entity p) {
+        if (a instanceof ArmorStand armorStand && p instanceof Player player && player.isShiftKeyDown() && armorStand.isMarker()) {
+            return ((ArmorStandAccessor) armorStand).getArmorstandDimensions(false).makeBoundingBox(armorStand.position());
+        }
+        return a.getBoundingBox();
+    }
+
+    @Redirect(method = "getEntityHitResult(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/Vec3;Lnet/minecraft/world/phys/AABB;Ljava/util/function/Predicate;D)Lnet/minecraft/world/phys/EntityHitResult;",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/Level;getEntities(Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/phys/AABB;Ljava/util/function/Predicate;)Ljava/util/List;"))
+    private static java.util.List<Entity> getEntities(Level level, Entity p, AABB aabb, Predicate<Entity> predicate) {
+        if (p instanceof Player player && player.isShiftKeyDown()) {
+            Predicate<Entity> allowMarkerArmorStands = entity -> (entity instanceof ArmorStand armorStand && armorStand.isMarker());
+            return level.getEntities(p, aabb, predicate.or(allowMarkerArmorStands));
+        }
+        return level.getEntities(p, aabb, predicate);
+    }
+}

--- a/Common/src/main/resources/armorstatues.common.mixins.json
+++ b/Common/src/main/resources/armorstatues.common.mixins.json
@@ -6,7 +6,8 @@
   "refmap": "armorstatues.refmap.json",
   "mixins": [
     "accessor.ArmorStandAccessor",
-    "accessor.SimpleContainerAccessor"
+    "accessor.SimpleContainerAccessor",
+    "redirect.MarkerArmorStandRaytracer"
   ],
   "client": [
   ],

--- a/Forge/src/generated/resources/assets/armorstatues/lang/en_us.json
+++ b/Forge/src/generated/resources/assets/armorstatues/lang/en_us.json
@@ -60,6 +60,8 @@
   "armorstatues.screen.style.noBasePlate.description": "Hide the stone base plate at the statue's feet.",
   "armorstatues.screen.style.noGravity": "No Gravity",
   "armorstatues.screen.style.noGravity.description": "Prevents the statue from falling down, so it may float freely.",
+  "armorstatues.screen.style.noHitbox": "No Hitbox",
+  "armorstatues.screen.style.noHitbox.description": "Allows to place blocks inside the statue, the statue will not fall down and it is no longer possible to interact with it.",
   "armorstatues.screen.style.sealed": "Sealed",
   "armorstatues.screen.style.sealed.description": "The statue can no longer be broken, equipment cannot be changed. Disallows opening this menu in survival mode.",
   "armorstatues.screen.style.showArms": "Show Arms",

--- a/Forge/src/main/java/fuzs/armorstatues/data/ModLanguageProvider.java
+++ b/Forge/src/main/java/fuzs/armorstatues/data/ModLanguageProvider.java
@@ -40,6 +40,7 @@ public class ModLanguageProvider extends LanguageProvider {
         this.add("armorstatues.screen.style.noGravity", "No Gravity");
         this.add("armorstatues.screen.style.glowing", "Glowing");
         this.add("armorstatues.screen.style.sealed", "Sealed");
+        this.add("armorstatues.screen.style.noHitbox", "No Hitbox");
         this.add("armorstatues.screen.style.showArms.description", "Shows the statue's arms, so it may hold items in both hands.");
         this.add("armorstatues.screen.style.small.description", "Makes the statue half it's size like a baby mob.");
         this.add("armorstatues.screen.style.invisible.description", "Makes the statue itself invisible, but still shows all equipped items.");
@@ -48,6 +49,7 @@ public class ModLanguageProvider extends LanguageProvider {
         this.add("armorstatues.screen.style.noGravity.description", "Prevents the statue from falling down, so it may float freely.");
         this.add("armorstatues.screen.style.glowing.description", "Adds a glowing outline to the statue, visible through blocks.");
         this.add("armorstatues.screen.style.sealed.description", "The statue can no longer be broken, equipment cannot be changed. Disallows opening this menu in survival mode.");
+        this.add("armorstatues.screen.style.sealed.noHitbox", "Allows to place blocks inside the statue, the statue will not fall down and it is no longer possible to interact with it.");
         this.add("armorstatues.screen.position.rotation", "Rotation:");
         this.add("armorstatues.screen.position.degrees", "%s\u00B0");
         this.add("armorstatues.screen.position.moveBy", "Move By:");


### PR DESCRIPTION
### Feature changes
**Added a flag to remove the Hitbox from statue.** (A.K.A. Marker NBT flag)

This allows to place blocks inside the statue, disable pistons pushing it, (also removing interagibility and gravity).

### Dev info
_To allow the interaction while sneaking, I redirected some "ProjectileUtil" static function used only during look-tracing._

_I didn't test the forge version 😥_